### PR TITLE
Add deck validation before playtest

### DIFF
--- a/web/src/app/playtest/[deckId]/page.tsx
+++ b/web/src/app/playtest/[deckId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import PlaytestClient from "@/components/PlaytestClient";
+import { validateDeckForPlaytest } from "@/lib/deckValidation";
 
 type CardRow = {
     id: string;
@@ -45,13 +46,13 @@ export default async function PlaytestDeckPage({
         .eq("id", deckId)
         .maybeSingle();
 
-    if (deckError || !deck) {
-        return (
-            <main className="p-6">
-                <p>Deck not found. ID: {deckId}</p>
-                <pre>{JSON.stringify(deckError, null, 2)}</pre>
-            </main>
-        );
+    if (deckError) {
+        console.error(deckError);
+        notFound();
+    }
+
+    if (!deck) {
+        notFound();
     }
 
     const { data: deckCardRows, error: deckCardsError } = await supa
@@ -61,31 +62,85 @@ export default async function PlaytestDeckPage({
 
     if (deckCardsError) {
         console.error(deckCardsError);
-        return <main className="p-6">Failed to load deck cards.</main>;
-    }
 
-    const cardIds = (deckCardRows ?? []).map((row: DeckCardRow) => row.card_id);
-
-    const { data: cardsData, error: cardsError } = await supa
-        .from("cards")
-        .select("id,name,type,cost,attack,defense")
-        .in("id", cardIds);
-
-    if (cardsError) {
         return (
             <main className="p-6">
-                <p>Failed to load card details.</p>
-                <pre>{JSON.stringify(cardsError, null, 2)}</pre>
+                <h1 className="text-2xl font-bold">Failed to load deck cards</h1>
+                <p className="mt-2 text-gray-600">
+                    Something went wrong while loading this deck&apos;s cards.
+                </p>
             </main>
         );
     }
 
-    const cardMap = new Map((cardsData ?? []).map((card: CardRow) => [card.id, card]));
+    const deckRows = deckCardRows ?? [];
+    const cardIds = deckRows.map((row: DeckCardRow) => row.card_id);
 
-    const expandedDeck: PlaytestCard[] = (deckCardRows ?? []).flatMap(
+    let cardsData: CardRow[] = [];
+
+    if (cardIds.length > 0) {
+        const { data, error: cardsError } = await supa
+            .from("cards")
+            .select("id,name,type,cost,attack,defense")
+            .in("id", cardIds);
+
+        if (cardsError) {
+            console.error(cardsError);
+
+            return (
+                <main className="p-6">
+                    <h1 className="text-2xl font-bold">Failed to load card details</h1>
+                    <p className="mt-2 text-gray-600">
+                        Something went wrong while loading the cards in this deck.
+                    </p>
+                </main>
+            );
+        }
+
+        cardsData = data ?? [];
+    }
+
+    const validation = validateDeckForPlaytest({
+        deckCards: deckRows,
+        cards: cardsData,
+        minDeckSize: 1,
+        maxDeckSize: 60,
+    });
+
+    if (!validation.valid) {
+        return (
+            <main className="mx-auto max-w-2xl p-6">
+                <h1 className="text-2xl font-bold">Deck cannot be playtested</h1>
+
+                <p className="mt-2 text-gray-600">
+                    This deck has one or more problems that need to be fixed before a match can start.
+                </p>
+
+                <ul className="mt-4 list-disc space-y-2 pl-6">
+                    {validation.issues.map((issue, index) => (
+                        <li key={`${issue.code}-${index}`}>{issue.message}</li>
+                    ))}
+                </ul>
+
+                <a
+                    href="/studio/decks"
+                    className="mt-6 inline-block rounded-lg border px-4 py-2"
+                >
+                    Back to Decks
+                </a>
+            </main>
+        );
+    }
+
+    const cardMap = new Map(cardsData.map((card: CardRow) => [card.id, card]));
+
+    const expandedDeck: PlaytestCard[] = deckRows.flatMap(
         (row: DeckCardRow, rowIndex: number) => {
             const card = cardMap.get(row.card_id);
-            if (!card) return [];
+
+            if (!card) {
+                return [];
+            }
 
             return Array.from({ length: row.qty }, (_, copyIndex) => ({
                 ...card,
@@ -93,10 +148,6 @@ export default async function PlaytestDeckPage({
             }));
         }
     );
-
-    if (expandedDeck.length === 0) {
-        return <main className="p-6">This deck has no cards and cannot be playtested yet.</main>;
-    }
 
     const shuffledDeck = shuffleDeck(expandedDeck);
 

--- a/web/src/lib/deckValidation.ts
+++ b/web/src/lib/deckValidation.ts
@@ -1,0 +1,106 @@
+export type DeckValidationIssue = {
+    code: string;
+    message: string;
+};
+
+export type DeckValidationResult = {
+    valid: boolean;
+    issues: DeckValidationIssue[];
+};
+
+export function validateDeckForPlaytest(params: {
+    deckCards: {
+        card_id: string;
+        qty: number;
+    }[];
+    cards: {
+        id: string;
+        name: string | null;
+        type?: string | null;
+        cost?: number | null;
+        attack?: number | null;
+        defense?: number | null;
+    }[];
+    minDeckSize?: number;
+    maxDeckSize?: number;
+}): DeckValidationResult {
+    const issues: DeckValidationIssue[] = [];
+
+    const { deckCards, cards, minDeckSize = 1, maxDeckSize = 60 } = params;
+
+    if (!deckCards || deckCards.length === 0) {
+        issues.push({
+            code: "EMPTY_DECK",
+            message: "This deck has no cards. Add cards before starting playtest.",
+        });
+    }
+
+    const totalCards = deckCards.reduce((sum, row) => sum + row.qty, 0);
+
+    if (totalCards < minDeckSize) {
+        issues.push({
+            code: "BELOW_MIN_SIZE",
+            message: `This deck has ${totalCards} card(s), but it needs at least ${minDeckSize}.`,
+        });
+    }
+
+    if (totalCards > maxDeckSize) {
+        issues.push({
+            code: "ABOVE_MAX_SIZE",
+            message: `This deck has ${totalCards} card(s), but the maximum allowed is ${maxDeckSize}.`,
+        });
+    }
+
+    const cardIds = new Set(cards.map((card) => card.id));
+
+    for (const deckCard of deckCards) {
+        if (!Number.isInteger(deckCard.qty) || deckCard.qty <= 0) {
+            issues.push({
+                code: "INVALID_QUANTITY",
+                message: "One or more cards has an invalid quantity.",
+            });
+        }
+
+        if (!cardIds.has(deckCard.card_id)) {
+            issues.push({
+                code: "MISSING_CARD_REFERENCE",
+                message: "This deck references a card that no longer exists.",
+            });
+        }
+    }
+
+    for (const card of cards) {
+        if (!card.name || card.name.trim() === "") {
+            issues.push({
+                code: "MISSING_CARD_NAME",
+                message: "One or more cards is missing a name.",
+            });
+        }
+
+        if (card.cost != null && card.cost < 0) {
+            issues.push({
+                code: "INVALID_COST",
+                message: "One or more cards has an invalid cost value.",
+            });
+        }
+
+        if (card.attack != null && card.attack < 0) {
+            issues.push({
+                code: "INVALID_ATTACK",
+                message: "One or more cards has an invalid attack value.",
+            });
+        }
+
+        if (card.defense != null && card.defense < 0) {
+            issues.push({
+                code: "INVALID_DEFENSE",
+                message: "One or more cards has an invalid defense value.",
+            });
+        }
+    }
+
+    return {
+        valid: issues.length === 0,
+        issues,
+    };
+}


### PR DESCRIPTION
This adds a deck validation step before entering playtest. The playtest route now checks that the selected deck exists, deck card rows load successfully, card details load successfully, the deck is not empty, card quantities are valid, referenced cards still exist, and card fields such as name, cost, attack, and defense are usable.

If validation fails, the user is shown a clear message explaining why the deck cannot be playtested instead of allowing broken data to reach the playtest client. If validation passes, the deck is expanded, shuffled, and passed into PlaytestClient as before.

This closes #46 by validating decks before playtest, #47 by handling invalid or incomplete decks with clear feedback, and partly addresses #36 by addressing empty/invalid deck edge cases that could otherwise cause crashes or undefined playtest behavior.