### PR TITLE
Finalizing legal actions and endgame conditions

### DIFF
--- a/web/src/lib/engine/init.ts
+++ b/web/src/lib/engine/init.ts
@@ -1,4 +1,4 @@
-import { MatchState, PlayerState, Phase } from "./types";
+import { MatchState, PlayerState, Phase, CardDefinition } from "./types";
 
 function seededRandom(seed: number) {
   let value = seed % 2147483647;
@@ -20,28 +20,28 @@ function shuffle<T>(array: T[], rand: () => number): T[] {
 export function createMatch(
   player1Deck: string[],
   player2Deck: string[],
+  cardDefinitions: Record<string, CardDefinition>,
   seed: number
 ): MatchState {
   const rand = seededRandom(seed);
-
   const p1Deck = shuffle(player1Deck, rand);
   const p2Deck = shuffle(player2Deck, rand);
-
   const startingPlayer = rand() < 0.5 ? "P1" : "P2";
 
- const basePlayer = (id: string, deck: string[]): PlayerState => {
-  const openingHand = deck.slice(0, 5);
-  const remainingDeck = deck.slice(5);
-
-  return {
-    id,
-    deck: remainingDeck,
-    hand: openingHand,
-    battlefield: [null, null, null, null, null],
-    discard: [],
-    resources: { current: 0, max: 0 },
+  const basePlayer = (id: string, deck: string[], isStarting: boolean): PlayerState => {
+    const openingHand = deck.slice(0, 5);
+    const remainingDeck = deck.slice(5);
+    return {
+      id,
+      deck: remainingDeck,
+      hand: openingHand,
+      battlefield: [null, null, null, null, null],
+      discard: [],
+      // Starting player begins turn 1 with 1 resource; non-starter gets theirs
+      // when the turn passes to them via END_PHASE (ruleset section 7).
+      resources: isStarting ? { current: 1, max: 1 } : { current: 0, max: 0 },
+    };
   };
-};
 
   return {
     version: "Alpha_Fixed_v0.1",
@@ -50,10 +50,13 @@ export function createMatch(
     activePlayer: startingPlayer,
     phase: Phase.DRAW,
     players: {
-      P1: basePlayer("P1", p1Deck),
-      P2: basePlayer("P2", p2Deck),
+      P1: basePlayer("P1", p1Deck, startingPlayer === "P1"),
+      P2: basePlayer("P2", p2Deck, startingPlayer === "P2"),
     },
     cardInstances: {},
+    cardDefinitions,
+    instanceCounter: 0,
     winner: null,
+    log: [`Match started. ${startingPlayer} goes first.`],
   };
 }

--- a/web/src/lib/engine/reducer.ts
+++ b/web/src/lib/engine/reducer.ts
@@ -1,10 +1,7 @@
-import { MatchState, Phase, PlayerState, CardType, CardInstance } from "./types";
-import { evaluateWinner } from "./winCondition";
+import { MatchState, Phase, CardType, CardInstance, ALPHA_RULES } from "./types";
+import { evaluateWinner, shouldEvaluateWin } from "./winCondition";
+import { validateAction, ValidationResult } from "./validation";
 
-/**
- * Apply an action to the match state and return a new updated state.
- * This is a pure function: does NOT mutate input state.
- */
 export type GameAction =
   | { type: "DRAW_CARD" }
   | { type: "PLAY_CREATURE"; cardId: string; slotIndex: number }
@@ -12,91 +9,144 @@ export type GameAction =
   | { type: "DECLARE_ATTACK"; attackerSlot: number; targetSlot: number }
   | { type: "END_PHASE" };
 
-export function applyAction(state: MatchState, action: GameAction): MatchState {
-  const newState: MatchState = JSON.parse(JSON.stringify(state)); // deep copy
+export interface DispatchResult {
+  state: MatchState;
+  validation: ValidationResult;
+}
+
+/**
+ * Public entrypoint. ALL action dispatch — UI clicks, AI moves — must go through here.
+ *
+ * Pipeline:
+ *   1. Validate via validation.ts (single gate).
+ *   2. If invalid: return original state unchanged + reason.
+ *   3. If valid: apply mutation, append log entry, evaluate win conditions.
+ */
+export function dispatch(
+  state: MatchState,
+  action: GameAction,
+  actorId: string
+): DispatchResult {
+  const validation = validateAction(state, action, actorId);
+  if (!validation.ok) {
+    return { state, validation };
+  }
+
+  const next = applyValidatedAction(state, action);
+  return { state: next, validation: { ok: true } };
+}
+
+/**
+ * Internal: applies an action that has ALREADY been validated.
+ * Pure function — does not mutate input.
+ *
+ * Do not export this directly. External callers should use `dispatch`.
+ */
+function applyValidatedAction(state: MatchState, action: GameAction): MatchState {
+  const newState: MatchState = JSON.parse(JSON.stringify(state));
   const activePlayer = newState.players[newState.activePlayer];
-  const opponent = newState.players[newState.activePlayer === "P1" ? "P2" : "P1"];
 
   switch (action.type) {
-    case "DRAW_CARD":
-      if (activePlayer.deck.length > 0) {
-        const cardId = activePlayer.deck.shift()!;
-        activePlayer.hand.push(cardId);
-      }
+    case "DRAW_CARD": {
+      const cardId = activePlayer.deck.shift()!;
+      activePlayer.hand.push(cardId);
+      newState.log.push(`${activePlayer.id} drew a card.`);
       break;
+    }
 
-    case "PLAY_CREATURE":
-      if (activePlayer.hand.includes(action.cardId)) {
-        const cardInstance: CardInstance = {
-          instanceId: `${action.cardId}_${Date.now()}`,
-          definitionId: action.cardId,
-          currentHealth: 1, // Placeholder: can pull actual health from definition
-          hasAttacked: false,
-          type: CardType.CREATURE, // Added type for win condition
-        };
+    case "PLAY_CREATURE": {
+      const def = newState.cardDefinitions[action.cardId];
+      const instanceId = `inst_${++newState.instanceCounter}`;
+      const cardInstance: CardInstance = {
+        instanceId,
+        definitionId: action.cardId,
+        type: CardType.CREATURE,
+        currentHealth: def.health!,
+        hasAttacked: false,
+      };
 
-        if (!activePlayer.battlefield[action.slotIndex]) {
-          activePlayer.hand = activePlayer.hand.filter((id) => id !== action.cardId);
-          activePlayer.battlefield[action.slotIndex] = cardInstance.instanceId;
-          newState.cardInstances[cardInstance.instanceId] = cardInstance;
-          // Deduct resource here if needed (simplified)
-        }
-      }
+      // Remove ONE copy from hand (handles duplicates correctly).
+      const handIdx = activePlayer.hand.indexOf(action.cardId);
+      activePlayer.hand.splice(handIdx, 1);
+
+      activePlayer.battlefield[action.slotIndex] = instanceId;
+      newState.cardInstances[instanceId] = cardInstance;
+      activePlayer.resources.current -= def.cost;
+
+      newState.log.push(
+        `${activePlayer.id} played ${action.cardId} to slot ${action.slotIndex}.`
+      );
       break;
+    }
 
-    case "PLAY_OBJECT":
-      if (activePlayer.hand.includes(action.cardId)) {
-        const cardInstance: CardInstance = {
-          instanceId: `${action.cardId}_${Date.now()}`,
-          definitionId: action.cardId,
-          hasAttacked: false,
-          type: CardType.OBJECT, // Added type
-        };
+    case "PLAY_OBJECT": {
+      const def = newState.cardDefinitions[action.cardId];
 
-        activePlayer.hand = activePlayer.hand.filter((id) => id !== action.cardId);
-        activePlayer.discard.push(action.cardId);
-        newState.cardInstances[cardInstance.instanceId] = cardInstance;
-        // Implement object effect here if needed
-      }
+      // Remove ONE copy from hand.
+      const handIdx = activePlayer.hand.indexOf(action.cardId);
+      activePlayer.hand.splice(handIdx, 1);
+
+      // Object resolves immediately and goes to discard. No instance is created
+      // (Alpha objects have no on-board presence — ruleset section 6).
+      activePlayer.discard.push(action.cardId);
+      activePlayer.resources.current -= def.cost;
+
+      // Alpha effects are limited to "deal damage" / "destroy target creature"
+      // (ruleset section 9). Specific effect resolution would go here once per-card
+      // effects are wired in. For now, objects play and discard with no effect —
+      // matching the current Alpha implementation scope.
+
+      newState.log.push(`${activePlayer.id} played object ${action.cardId}.`);
       break;
+    }
 
-    case "DECLARE_ATTACK":
-      const attackerId = activePlayer.battlefield[action.attackerSlot];
-      if (!attackerId) break;
+    case "DECLARE_ATTACK": {
+      const opponentId = newState.activePlayer === "P1" ? "P2" : "P1";
+      const opponent = newState.players[opponentId];
 
-      const attacker = newState.cardInstances[attackerId];
-      if (attacker.hasAttacked) break;
+      const attackerInstanceId = activePlayer.battlefield[action.attackerSlot]!;
+      const attacker = newState.cardInstances[attackerInstanceId];
+      const attackerDef = newState.cardDefinitions[attacker.definitionId];
 
-      // ✅ Mark attacker as having attacked BEFORE any possible deletion
       attacker.hasAttacked = true;
 
-      const defenderId = opponent.battlefield[action.targetSlot];
-      if (defenderId) {
-        const defender = newState.cardInstances[defenderId];
+      const defenderInstanceId = opponent.battlefield[action.targetSlot];
+      if (defenderInstanceId) {
+        // Creature vs Creature — simultaneous damage (ruleset section 8).
+        const defender = newState.cardInstances[defenderInstanceId];
+        const defenderDef = newState.cardDefinitions[defender.definitionId];
 
-        // Deal damage (placeholder logic)
-        defender.currentHealth! -= 1;
-        attacker.currentHealth! -= 1;
+        defender.currentHealth! -= attackerDef.attack!;
+        attacker.currentHealth! -= defenderDef.attack!;
 
-        // Remove defender if dead
+        newState.log.push(
+          `${activePlayer.id}'s ${attacker.definitionId} attacked ${defender.definitionId}.`
+        );
+
         if (defender.currentHealth! <= 0) {
           opponent.battlefield[action.targetSlot] = null;
           opponent.discard.push(defender.definitionId);
-          delete newState.cardInstances[defenderId];
+          delete newState.cardInstances[defenderInstanceId];
+          newState.log.push(`${defender.definitionId} was destroyed.`);
         }
-
-        // Remove attacker if dead
         if (attacker.currentHealth! <= 0) {
           activePlayer.battlefield[action.attackerSlot] = null;
           activePlayer.discard.push(attacker.definitionId);
-          delete newState.cardInstances[attackerId];
+          delete newState.cardInstances[attackerInstanceId];
+          newState.log.push(`${attacker.definitionId} was destroyed.`);
         }
       } else {
-        // Attack empty slot → could implement direct damage or ignore
+        // Direct pressure — empty slot. Alpha doesn't define direct damage to a
+        // player health total (creature exhaustion is the only loss condition),
+        // so this is a no-op except for marking hasAttacked. Logged for clarity.
+        newState.log.push(
+          `${activePlayer.id}'s ${attacker.definitionId} attacked an empty slot.`
+        );
       }
       break;
+    }
 
-    case "END_PHASE":
+    case "END_PHASE": {
       switch (newState.phase) {
         case Phase.DRAW:
           newState.phase = Phase.ACTION;
@@ -107,29 +157,44 @@ export function applyAction(state: MatchState, action: GameAction): MatchState {
         case Phase.COMBAT:
           newState.phase = Phase.END;
           break;
-        case Phase.END:
-          // Pass turn to opponent
+        case Phase.END: {
+          // Pass turn.
           newState.activePlayer = newState.activePlayer === "P1" ? "P2" : "P1";
           newState.turn += 1;
           newState.phase = Phase.DRAW;
 
-          // Gain 1 resource and refresh to max
           const ap = newState.players[newState.activePlayer];
+          // Resource gain per ruleset section 7.
           ap.resources.max += 1;
           ap.resources.current = ap.resources.max;
-
-          // Reset all creatures' attack flags
+          // Refresh attack flags.
           ap.battlefield.forEach((id) => {
             if (id) newState.cardInstances[id].hasAttacked = false;
           });
+          newState.log.push(`Turn ${newState.turn}: ${newState.activePlayer}'s turn.`);
           break;
+        }
       }
       break;
+    }
   }
 
-  // Evaluate win condition after each action
-  const winner = evaluateWinner(newState);
-  newState.winner = winner;
+  // Win evaluation per ruleset section 3: only after Combat or at End phase.
+  if (shouldEvaluateWin(newState.phase)) {
+    const winner = evaluateWinner(newState);
+    if (winner !== null) {
+      newState.winner = winner;
+      newState.log.push(
+        winner === "DRAW" ? `Match ended in a draw.` : `${winner} wins!`
+      );
+    }
+  }
 
   return newState;
+}
+
+// Backwards-compatible export for any code still calling applyAction directly.
+// New code should use `dispatch` instead.
+export function applyAction(state: MatchState, action: GameAction): MatchState {
+  return dispatch(state, action, state.activePlayer).state;
 }

--- a/web/src/lib/engine/types.ts
+++ b/web/src/lib/engine/types.ts
@@ -13,25 +13,25 @@ export enum CardType {
 export interface CardDefinition {
   id: string;
   type: CardType;
-  cost: number;
-  attack?: number;
-  health?: number;
+  cost: number;     // 0-10
+  attack?: number;  // 1-5, creatures only
+  health?: number;  // 1-10, creatures only
 }
 
 export interface CardInstance {
   instanceId: string;
   definitionId: string;
-  currentHealth?: number;
-  hasAttacked?: boolean;
-  type: CardType
+  type: CardType;
+  currentHealth?: number; // creatures only
+  hasAttacked?: boolean;  // creatures only
 }
 
 export interface PlayerState {
   id: string;
-  deck: string[];
-  hand: string[];
-  battlefield: (string | null)[];
-  discard: string[];
+  deck: string[];          // card definition IDs, ordered
+  hand: string[];          // card definition IDs
+  battlefield: (string | null)[]; // length 5, holds instanceIds
+  discard: string[];       // card definition IDs
   resources: {
     current: number;
     max: number;
@@ -46,5 +46,21 @@ export interface MatchState {
   phase: Phase;
   players: Record<string, PlayerState>;
   cardInstances: Record<string, CardInstance>;
+  cardDefinitions: Record<string, CardDefinition>; // lookup table
+  instanceCounter: number; // deterministic ID generation
   winner: string | "DRAW" | null;
+  log: string[]; // action log for UI / debugging
 }
+
+// Constants from the Alpha Ruleset
+export const ALPHA_RULES = {
+  DECK_SIZE: 30,
+  MIN_CREATURES_PER_DECK: 10,
+  STARTING_HAND_SIZE: 5,
+  BATTLEFIELD_SLOTS: 5,
+  STAT_RANGES: {
+    HEALTH: { min: 1, max: 10 },
+    ATTACK: { min: 1, max: 5 },
+    COST: { min: 0, max: 10 },
+  },
+} as const;

--- a/web/src/lib/engine/validation.ts
+++ b/web/src/lib/engine/validation.ts
@@ -1,1 +1,217 @@
-// Diddly diss, a placeholder for this.
+import {
+  MatchState,
+  Phase,
+  CardType,
+  CardDefinition,
+  ALPHA_RULES,
+} from "./types";
+import { GameAction } from "./reducer";
+
+export type ValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+/**
+ * Single validation gate for all game actions.
+ * Every action — user OR AI — must pass through this function before reaching the reducer.
+ *
+ * Returns { ok: true } if the action is legal in the current state.
+ * Returns { ok: false, reason } if rejected, with a human-readable reason for the UI/log.
+ */
+export function validateAction(
+  state: MatchState,
+  action: GameAction,
+  actorId: string
+): ValidationResult {
+  // 1. Terminal state check — no actions allowed once a match has ended.
+  if (state.winner !== null) {
+    return { ok: false, reason: "Match has ended." };
+  }
+
+  // 2. Turn ownership — only the active player may act.
+  if (actorId !== state.activePlayer) {
+    return { ok: false, reason: "Not your turn." };
+  }
+
+  const activePlayer = state.players[state.activePlayer];
+  if (!activePlayer) {
+    return { ok: false, reason: "Active player not found in state." };
+  }
+
+  switch (action.type) {
+    case "DRAW_CARD": {
+      if (state.phase !== Phase.DRAW) {
+        return { ok: false, reason: "Can only draw during the Draw Phase." };
+      }
+      if (activePlayer.deck.length === 0) {
+        return { ok: false, reason: "Deck is empty." };
+      }
+      return { ok: true };
+    }
+
+    case "PLAY_CREATURE": {
+      if (state.phase !== Phase.ACTION) {
+        return { ok: false, reason: "Can only play cards during the Action Phase." };
+      }
+      if (!activePlayer.hand.includes(action.cardId)) {
+        return { ok: false, reason: "Card is not in your hand." };
+      }
+      const def = state.cardDefinitions[action.cardId];
+      if (!def) {
+        return { ok: false, reason: "Unknown card definition." };
+      }
+      if (def.type !== CardType.CREATURE) {
+        return { ok: false, reason: "Card is not a Creature." };
+      }
+      if (
+        action.slotIndex < 0 ||
+        action.slotIndex >= ALPHA_RULES.BATTLEFIELD_SLOTS ||
+        !Number.isInteger(action.slotIndex)
+      ) {
+        return { ok: false, reason: "Invalid slot index." };
+      }
+      if (activePlayer.battlefield[action.slotIndex] !== null) {
+        return { ok: false, reason: "Slot is already occupied." };
+      }
+      if (activePlayer.resources.current < def.cost) {
+        return { ok: false, reason: "Not enough resources." };
+      }
+      return { ok: true };
+    }
+
+    case "PLAY_OBJECT": {
+      if (state.phase !== Phase.ACTION) {
+        return { ok: false, reason: "Can only play cards during the Action Phase." };
+      }
+      if (!activePlayer.hand.includes(action.cardId)) {
+        return { ok: false, reason: "Card is not in your hand." };
+      }
+      const def = state.cardDefinitions[action.cardId];
+      if (!def) {
+        return { ok: false, reason: "Unknown card definition." };
+      }
+      if (def.type !== CardType.OBJECT) {
+        return { ok: false, reason: "Card is not an Object." };
+      }
+      if (activePlayer.resources.current < def.cost) {
+        return { ok: false, reason: "Not enough resources." };
+      }
+      return { ok: true };
+    }
+
+    case "DECLARE_ATTACK": {
+      if (state.phase !== Phase.COMBAT) {
+        return { ok: false, reason: "Can only attack during the Combat Phase." };
+      }
+      const slots = ALPHA_RULES.BATTLEFIELD_SLOTS;
+      if (
+        action.attackerSlot < 0 ||
+        action.attackerSlot >= slots ||
+        !Number.isInteger(action.attackerSlot)
+      ) {
+        return { ok: false, reason: "Invalid attacker slot." };
+      }
+      if (
+        action.targetSlot < 0 ||
+        action.targetSlot >= slots ||
+        !Number.isInteger(action.targetSlot)
+      ) {
+        return { ok: false, reason: "Invalid target slot." };
+      }
+      const attackerInstanceId = activePlayer.battlefield[action.attackerSlot];
+      if (!attackerInstanceId) {
+        return { ok: false, reason: "No creature in attacker slot." };
+      }
+      const attacker = state.cardInstances[attackerInstanceId];
+      if (!attacker) {
+        return { ok: false, reason: "Attacker instance not found." };
+      }
+      if (attacker.type !== CardType.CREATURE) {
+        return { ok: false, reason: "Only creatures can attack." };
+      }
+      if (attacker.hasAttacked) {
+        return { ok: false, reason: "Creature has already attacked this turn." };
+      }
+      // Note: attacking an empty opposing slot is legal (direct pressure per ruleset 8.3).
+      return { ok: true };
+    }
+
+    case "END_PHASE": {
+      // Always legal for the active player; phase transitions are unconditional.
+      return { ok: true };
+    }
+
+    default: {
+      // Exhaustiveness check — if a new action type is added, TS will flag this.
+      const _exhaustive: never = action;
+      return { ok: false, reason: "Unknown action type." };
+    }
+  }
+}
+
+/**
+ * Deck validation per ruleset section 11.
+ */
+export function validateDeck(
+  deckCardIds: string[],
+  cardDefinitions: Record<string, CardDefinition>
+): ValidationResult {
+  if (deckCardIds.length !== ALPHA_RULES.DECK_SIZE) {
+    return {
+      ok: false,
+      reason: `Deck must contain exactly ${ALPHA_RULES.DECK_SIZE} cards (has ${deckCardIds.length}).`,
+    };
+  }
+
+  let creatureCount = 0;
+  for (const cardId of deckCardIds) {
+    const def = cardDefinitions[cardId];
+    if (!def) {
+      return { ok: false, reason: `Unknown card in deck: ${cardId}` };
+    }
+    const cardCheck = validateCardDefinition(def);
+    if (!cardCheck.ok) {
+      return { ok: false, reason: `Card ${cardId}: ${cardCheck.reason}` };
+    }
+    if (def.type === CardType.CREATURE) creatureCount++;
+  }
+
+  if (creatureCount < ALPHA_RULES.MIN_CREATURES_PER_DECK) {
+    return {
+      ok: false,
+      reason: `Deck must contain at least ${ALPHA_RULES.MIN_CREATURES_PER_DECK} Creature cards (has ${creatureCount}).`,
+    };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Card definition validation per ruleset section 11.
+ * Ensures stats fall within defined ranges.
+ */
+export function validateCardDefinition(def: CardDefinition): ValidationResult {
+  const { COST, HEALTH, ATTACK } = ALPHA_RULES.STAT_RANGES;
+
+  if (!def.id) return { ok: false, reason: "Missing card id." };
+  if (def.cost < COST.min || def.cost > COST.max) {
+    return { ok: false, reason: `Cost out of range (${COST.min}-${COST.max}).` };
+  }
+
+  if (def.type === CardType.CREATURE) {
+    if (def.health === undefined) {
+      return { ok: false, reason: "Creature missing health." };
+    }
+    if (def.attack === undefined) {
+      return { ok: false, reason: "Creature missing attack." };
+    }
+    if (def.health < HEALTH.min || def.health > HEALTH.max) {
+      return { ok: false, reason: `Health out of range (${HEALTH.min}-${HEALTH.max}).` };
+    }
+    if (def.attack < ATTACK.min || def.attack > ATTACK.max) {
+      return { ok: false, reason: `Attack out of range (${ATTACK.min}-${ATTACK.max}).` };
+    }
+  }
+
+  return { ok: true };
+}

--- a/web/src/lib/engine/winCondition.ts
+++ b/web/src/lib/engine/winCondition.ts
@@ -1,39 +1,47 @@
-import { MatchState, PlayerState, CardType, CardInstance } from "./types";
+import { MatchState, PlayerState, CardType, CardInstance, Phase } from "./types";
 
 /**
- * Check if a single player has any Creature cards left
+ * Per ruleset section 3, win conditions are only evaluated:
+ *   - After the Combat Phase
+ *   - At the End Phase
+ * This helper lets the reducer skip evaluation during DRAW / ACTION phases
+ * for correctness and minor perf.
  */
+export function shouldEvaluateWin(phase: Phase): boolean {
+  return phase === Phase.COMBAT || phase === Phase.END;
+}
+
 function hasCreatures(
   player: PlayerState,
-  cardInstances: Record<string, CardInstance>
+  cardInstances: Record<string, CardInstance>,
+  cardDefinitions: Record<string, { type: CardType }>
 ): boolean {
-  // Helper to check if a card instance is a creature
-  const isCreature = (id: string) => {
-    const card = cardInstances[id];
-    return card && card.type === CardType.CREATURE;
-  };
-
-  // Check battlefield, hand, and deck for creatures
-  return (
-    player.battlefield.some((id) => id !== null && isCreature(id)) ||
-    player.hand.some(isCreature) ||
-    player.deck.some(isCreature)
+  // Battlefield holds instanceIds; check the instance type.
+  const battlefieldHasCreature = player.battlefield.some(
+    (id) => id !== null && cardInstances[id]?.type === CardType.CREATURE
   );
+  if (battlefieldHasCreature) return true;
+
+  // Hand and deck hold definitionIds; look up via cardDefinitions.
+  const isCreatureDef = (defId: string) =>
+    cardDefinitions[defId]?.type === CardType.CREATURE;
+
+  return player.hand.some(isCreatureDef) || player.deck.some(isCreatureDef);
 }
 
 /**
- * Evaluate the winner based on Creature Exhaustion rule
+ * Creature Exhaustion (ruleset section 3):
+ *   A player loses when they have no Creature cards remaining in
+ *   deck, hand, or battlefield. Simultaneous loss = DRAW.
  */
 export function evaluateWinner(state: MatchState): string | "DRAW" | null {
   const p1 = state.players["P1"];
   const p2 = state.players["P2"];
-
-  const p1HasCreatures = hasCreatures(p1, state.cardInstances);
-  const p2HasCreatures = hasCreatures(p2, state.cardInstances);
+  const p1HasCreatures = hasCreatures(p1, state.cardInstances, state.cardDefinitions);
+  const p2HasCreatures = hasCreatures(p2, state.cardInstances, state.cardDefinitions);
 
   if (!p1HasCreatures && !p2HasCreatures) return "DRAW";
   if (!p1HasCreatures) return "P2";
   if (!p2HasCreatures) return "P1";
-
-  return null; // No winner yet
+  return null;
 }


### PR DESCRIPTION
Sprint 1 engine work for valid action enforcement and end condition reliability. Adds a single validation gate (`validation.ts`) that all game actions must pass through before mutating state, refactors the reducer to route actions through `dispatch()` with terminal-state  guarding once a winner is determined, and fixes win evaluation timing  to match Alpha Ruleset section 3 (Combat/End phases only). 

Also includes incidental bug fixes: deterministic instance IDs, real card stats pulled from definitions, correct duplicate handling in hand removal, removed leaking object instances, and proper resource cost deduction. All changes are scoped to `src/lib/engine/`. 

Note: `PlaytestClient.tsx` maintains its own game state separate from the engine, so this PR is engine infrastructure — UI integration is a follow-up. Vercel build green, 17 engine unit tests passing.