### PR TITLE
Polish deck selection and playtest entry flow

### DIFF
--- a/web/src/app/playtest/page.tsx
+++ b/web/src/app/playtest/page.tsx
@@ -1,25 +1,96 @@
 import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
 
-export default function PlaytestPage() {
-  return (
-    <main className="mx-auto max-w-4xl p-6 space-y-4">
-      <div>
-        <h1 className="text-2xl font-semibold">Playtest</h1>
-        <p className="mt-1 text-sm text-gray-500">Test your deck against an AI opponent.</p>
-      </div>
+export default async function PlaytestDeckSelectPage() {
+  const supabase = await createClient();
 
-      <div className="rounded border border-gray-300 shadow-sm p-5 space-y-2">
-        <div className="font-medium">No deck selected</div>
-        <p className="text-sm text-gray-500">
-          Go to your decks, build or pick a deck, then click <strong>Playtest</strong> to start a game.
+  const { data: decks, error } = await supabase
+    .from("decks")
+    .select(`
+      id,
+      name,
+      created_at,
+      deck_cards (
+        qty
+      )
+    `)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    return (
+      <main className="mx-auto max-w-5xl p-6">
+        <h1 className="text-3xl font-bold">Choose a Deck</h1>
+        <p className="mt-4 text-red-500">
+          There was a problem loading your decks.
         </p>
-        <Link
-          href="/studio/decks"
-          className="mt-2 inline-block rounded bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 transition"
-        >
-          Go to My Decks
-        </Link>
-      </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-5xl p-6">
+      <section className="mb-8">
+        <h1 className="text-3xl font-bold">Choose a Deck to Playtest</h1>
+        <p className="mt-2 text-gray-600">
+          Select one of your saved decks below, then start playtest mode.
+        </p>
+      </section>
+
+      {!decks || decks.length === 0 ? (
+        <div className="rounded-lg border p-6">
+          <h2 className="text-xl font-semibold">No decks available</h2>
+          <p className="mt-2 text-gray-600">
+            You need to create a deck before entering playtest mode.
+          </p>
+
+          <Link
+            href="/deck-builder"
+            className="mt-4 inline-block rounded bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-700"
+          >
+            Create a Deck
+          </Link>
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          {decks.map((deck) => {
+            const cardCount =
+              deck.deck_cards?.reduce(
+                (total: number, card: { qty: number | null }) =>
+                  total + (card.qty ?? 0),
+                0
+              ) ?? 0;
+
+            return (
+              <div
+                key={deck.id}
+                className="rounded-lg border bg-white p-5 shadow-sm"
+              >
+                <h2 className="text-xl font-semibold">{deck.name}</h2>
+
+                <p className="mt-2 text-sm text-gray-600">
+                  {cardCount} card{cardCount === 1 ? "" : "s"} in this deck
+                </p>
+
+                <div className="mt-5 flex gap-3">
+                  <Link
+                    href={`/playtest/${deck.id}`}
+                    className="rounded bg-green-600 px-4 py-2 font-medium text-white hover:bg-green-700"
+                  >
+                    Start Playtest
+                  </Link>
+
+                  <Link
+                    href="/deck-builder"
+                    className="rounded border px-4 py-2 font-medium hover:bg-gray-100"
+                  >
+                    Edit Decks
+                  </Link>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
Polished the deck selection and playtest entry flow.

Changes:
- Added a clear deck selection page
- Displays available saved decks before entering playtest mode
- Shows card counts for each deck
- Added clear Start Playtest buttons for each deck
- Added an empty state when no decks are available
- Improved user guidance so players understand which deck they are choosing before starting